### PR TITLE
feat : add report hadling function to handle request of report_record  from pubsub

### DIFF
--- a/src/action/action.py
+++ b/src/action/action.py
@@ -10,6 +10,7 @@ from src.action.like import like_handler
 from src.action.category import category_handler
 from src.action.member import member_handler
 from src.action.collection import collection_handler
+from src.action.report import report_handler
 
 def execute(content):
     if 'action' in content and content['action']:
@@ -36,4 +37,6 @@ def execute(content):
             return collection_handler(content)
         if 'read' in action:
             return True
+        if 'report' in action:
+            return report_handler(content, gql_client)
     return False

--- a/src/action/report.py
+++ b/src/action/report.py
@@ -13,17 +13,17 @@ def report_handler(content, gql_client):
         return False
 
     report_gql = None
+    gql_endpoint = os.environ['GQL_ENDPOINT']
+    respondentId = None
     if obj == 'comment':
         report_gql = gql_comment_member
-    else:
-        report_gql = gql_collection_member
-    gql_endpoint = os.environ['GQL_ENDPOINT']
-    respondentId, _ = gql_query(gql_endpoint, report_gql.format(ID=targetId))
-    
-    if obj == 'comment':
+        respondentId, _ = gql_query(gql_endpoint, report_gql.format(ID=targetId))
         respondentId = respondentId['comment']['member']['id']
     else:
+        report_gql = gql_collection_member
+        respondentId, _ = gql_query(gql_endpoint, report_gql.format(ID=targetId))
         respondentId = respondentId['collection']['creator']['id']
+    
     action = content['action']
     if action == 'add_report_record':
         try:

--- a/src/action/report.py
+++ b/src/action/report.py
@@ -12,27 +12,27 @@ def report_handler(content, gql_client):
         print("no required data for action")
         return False
 
-    comment = content['comment']
     report_gql = None
-    if comment:
+    if obj == 'comment':
         report_gql = gql_comment_member
     else:
         report_gql = gql_collection_member
     gql_endpoint = os.environ['GQL_ENDPOINT']
     respondentId, _ = gql_query(gql_endpoint, report_gql.format(ID=targetId))
     
-    if comment:
+    if obj == 'comment':
         respondentId = respondentId['comment']['member']['id']
     else:
         respondentId = respondentId['collection']['creator']['id']
-    if content['action'] == 'add_report_record':
+    action = content['action']
+    if action == 'add_report_record':
         try:
             fields = [
                 f"informant:{{connect:{{id:{memberId}}}}}",
                 f"reason:{{connect:{{id:{reasonId}}}}}",
                 f"respondent:{{connect:{{id:{respondentId}}}}}",
             ]
-            if comment:
+            if obj == 'comment':
                 fields.append(f"comment:{{connect:{{id:{targetId}}}}}")
             else:
                 fields.append(f"collection:{{connect:{{id:{targetId}}}}}")

--- a/src/action/report.py
+++ b/src/action/report.py
@@ -1,0 +1,59 @@
+from src.gql import gql_collection_member, gql_comment_member, gql_query
+import os
+from gql import gql
+
+
+def report_handler(content, gql_client):
+    memberId = content['memberId'] if 'memberId' in content and content['memberId'] else False
+    targetId = content['targetId'] if 'targetId' in content and content['targetId'] else False
+    obj = content['objective'] if 'objective' in content and content['objective'] else False
+    reasonId = content['reasonId'] if 'reasonId' in content and content['reasonId'] else False
+    if not (memberId or targetId or obj or reasonId or 'comment' not in content):
+        print("no required data for action")
+        return False
+
+    comment = content['comment']
+    report_gql = None
+    if comment:
+        report_gql = gql_comment_member
+    else:
+        report_gql = gql_collection_member
+    gql_endpoint = os.environ['GQL_ENDPOINT']
+    respondentId, _ = gql_query(gql_endpoint, report_gql.format(ID=targetId))
+    
+    if comment:
+        respondentId = respondentId['comment']['member']['id']
+    else:
+        respondentId = respondentId['collection']['creator']['id']
+    if content['action'] == 'add_report_record':
+        try:
+            fields = [
+                f"informant:{{connect:{{id:{memberId}}}}}",
+                f"reason:{{connect:{{id:{reasonId}}}}}",
+                f"respondent:{{connect:{{id:{respondentId}}}}}",
+            ]
+            if comment:
+                fields.append(f"comment:{{connect:{{id:{targetId}}}}}")
+            else:
+                fields.append(f"collection:{{connect:{{id:{targetId}}}}}")
+
+            fields_string = ", ".join(fields)
+
+            mutation = f'''
+                mutation {{
+                    createReportRecord(data:{{
+                        {fields_string}
+                    }})
+                    {{
+                        id
+                    }}
+                }}
+            '''
+            result = gql_client.execute(gql(mutation))
+            return True if isinstance(result, dict) and 'createReportRecord' in result else False
+        except Exception as e:
+            print(f"add_report failed: {str(e)}")
+    return False
+
+
+

--- a/src/gql.py
+++ b/src/gql.py
@@ -152,3 +152,28 @@ mutation updateInvitationCodes($data: [InvitationCodeUpdateArgs!]!){
   }
 }
 '''
+
+### 查詢該集錦屬於哪個用戶
+gql_collection_member = '''
+query Collection{{
+    collection(where: {{id: {ID} }}){{
+        creator {{
+            id
+            name
+        }}
+    }}
+}}
+'''
+
+### 查詢該留言屬於哪個用戶
+gql_comment_member = '''
+query Comment{{
+    comment(where: {{id: {ID} }}){{
+        member {{
+            id
+            name
+        }}
+        content
+    }}
+}}
+'''


### PR DESCRIPTION
此份PR 新增了處理檢舉留言pubsub的處理程序
主要會傳入的pubsub 資料結構如下
{
        'action': 'add_report_record',
        'memberId': '2',
        'objective': 'comment',  # or 'collection'
        'targetId': '96',
        'reasonId':'3’,
}

會針對objective判斷被檢舉的是留言or集錦
targetId 為 檢舉的留言or集錦id
memberId 為檢舉人
reasonId為選擇的檢舉原因